### PR TITLE
Implement BT-HID Android Bluetooth HID Device MVP

### DIFF
--- a/android-client/.gitignore
+++ b/android-client/.gitignore
@@ -1,0 +1,9 @@
+*.iml
+.gradle
+/local.properties
+/.idea/
+.DS_Store
+/build
+/captures
+.externalNativeBuild
+.cxx

--- a/android-client/README.md
+++ b/android-client/README.md
@@ -1,1 +1,10 @@
-Android client (phone controller)
+# Android Client (Bluetooth HID MVP)
+
+This directory contains a full Android Studio Kotlin project for milestone **BT-HID**.
+
+## What it does
+- Registers the Android phone as a Bluetooth HID combo device (mouse + keyboard).
+- Sends relative mouse movement, left click, and wheel scroll.
+- Sends basic keyboard HID key events for letters, numbers, space, and enter.
+
+See `docs/how-to-run-bluetooth-hid.md` for setup and usage.

--- a/android-client/app/build.gradle.kts
+++ b/android-client/app/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.remotebrain.hid"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.remotebrain.hid"
+        minSdk = 28
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+}

--- a/android-client/app/proguard-rules.pro
+++ b/android-client/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Intentionally minimal for MVP.

--- a/android-client/app/src/main/AndroidManifest.xml
+++ b/android-client/app/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature android:name="android.hardware.bluetooth" android:required="true" />
+
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.RemoteBrainHid">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android-client/app/src/main/java/com/remotebrain/hid/HidDeviceManager.kt
+++ b/android-client/app/src/main/java/com/remotebrain/hid/HidDeviceManager.kt
@@ -1,0 +1,253 @@
+package com.remotebrain.hid
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothHidDevice
+import android.bluetooth.BluetoothHidDeviceAppQosSettings
+import android.bluetooth.BluetoothHidDeviceAppSdpSettings
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.core.content.ContextCompat
+import java.util.concurrent.Executor
+
+class HidDeviceManager(
+    private val context: Context,
+    private val listener: Listener
+) {
+    interface Listener {
+        fun onStatusChanged(text: String)
+        fun onDeviceConnected(connected: Boolean)
+    }
+
+    private var bluetoothHidDevice: BluetoothHidDevice? = null
+    private var connectedDevice: BluetoothDevice? = null
+
+    private val callback = object : BluetoothHidDevice.Callback() {
+        override fun onAppStatusChanged(pluggedDevice: BluetoothDevice?, registered: Boolean) {
+            listener.onStatusChanged(if (registered) "HID profile registered" else "HID profile not registered")
+        }
+
+        override fun onConnectionStateChanged(device: BluetoothDevice, state: Int) {
+            when (state) {
+                BluetoothProfile.STATE_CONNECTED -> {
+                    connectedDevice = device
+                    listener.onStatusChanged("Connected to ${device.name ?: device.address}")
+                    listener.onDeviceConnected(true)
+                }
+
+                BluetoothProfile.STATE_CONNECTING -> listener.onStatusChanged("Connecting to ${device.name ?: device.address}...")
+                else -> {
+                    connectedDevice = null
+                    listener.onStatusChanged("Not connected")
+                    listener.onDeviceConnected(false)
+                }
+            }
+        }
+    }
+
+    private val profileListener = object : BluetoothProfile.ServiceListener {
+        override fun onServiceConnected(profile: Int, proxy: BluetoothProfile?) {
+            bluetoothHidDevice = proxy as? BluetoothHidDevice
+            listener.onStatusChanged("Bluetooth HID service ready")
+        }
+
+        override fun onServiceDisconnected(profile: Int) {
+            bluetoothHidDevice = null
+            connectedDevice = null
+            listener.onStatusChanged("Bluetooth HID service disconnected")
+            listener.onDeviceConnected(false)
+        }
+    }
+
+    fun bindService() {
+        val adapter = BluetoothAdapter.getDefaultAdapter() ?: run {
+            listener.onStatusChanged("Bluetooth not supported")
+            return
+        }
+        adapter.getProfileProxy(context, profileListener, BluetoothProfile.HID_DEVICE)
+    }
+
+    fun registerAndConnect() {
+        val adapter = BluetoothAdapter.getDefaultAdapter() ?: return
+        if (!adapter.isEnabled) {
+            listener.onStatusChanged("Enable Bluetooth first")
+            return
+        }
+
+        if (!hasConnectPermission()) {
+            listener.onStatusChanged("Bluetooth permissions missing")
+            return
+        }
+
+        val hid = bluetoothHidDevice
+        if (hid == null) {
+            listener.onStatusChanged("HID service not ready yet")
+            return
+        }
+
+        val sdp = BluetoothHidDeviceAppSdpSettings(
+            "RemoteBrain HID",
+            "RemoteBrain phone mouse/keyboard",
+            "RemoteBrain",
+            BluetoothHidDevice.SUBCLASS1_COMBO,
+            HID_REPORT_DESCRIPTOR
+        )
+
+        val executor = Executor { it.run() }
+        val registerResult = hid.registerApp(sdp, null as BluetoothHidDeviceAppQosSettings?, null, executor, callback)
+        if (!registerResult) {
+            listener.onStatusChanged("Failed to register HID app")
+            return
+        }
+
+        val target = adapter.bondedDevices?.firstOrNull()
+        if (target == null) {
+            listener.onStatusChanged("Pair with a host first (Windows, etc.)")
+            return
+        }
+
+        hid.connect(target)
+    }
+
+    fun sendMouseMove(dx: Int, dy: Int) {
+        val report = byteArrayOf(
+            0x00,
+            clampToSignedByte(dx),
+            clampToSignedByte(dy),
+            0x00
+        )
+        sendReport(REPORT_ID_MOUSE, report)
+    }
+
+    fun sendMouseClickLeft() {
+        sendReport(REPORT_ID_MOUSE, byteArrayOf(0x01, 0x00, 0x00, 0x00))
+        sendReport(REPORT_ID_MOUSE, byteArrayOf(0x00, 0x00, 0x00, 0x00))
+    }
+
+    fun sendScroll(deltaY: Int) {
+        val report = byteArrayOf(
+            0x00,
+            0x00,
+            0x00,
+            clampToSignedByte(-deltaY)
+        )
+        sendReport(REPORT_ID_MOUSE, report)
+    }
+
+    fun sendText(text: String) {
+        text.forEach { c ->
+            val keycode = keycodeForChar(c) ?: return@forEach
+            sendKeyboardKey(keycode, c.isUpperCase())
+        }
+    }
+
+    private fun sendKeyboardKey(keycode: Byte, useShift: Boolean) {
+        val modifier = if (useShift) 0x02.toByte() else 0x00
+        val keyDown = byteArrayOf(modifier, 0x00, keycode, 0x00, 0x00, 0x00, 0x00, 0x00)
+        val keyUp = byteArrayOf(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+        sendReport(REPORT_ID_KEYBOARD, keyDown)
+        sendReport(REPORT_ID_KEYBOARD, keyUp)
+    }
+
+    private fun sendReport(reportId: Int, data: ByteArray) {
+        val hid = bluetoothHidDevice
+        val device = connectedDevice
+        if (hid == null || device == null) {
+            listener.onStatusChanged("Not connected")
+            return
+        }
+        val ok = hid.sendReport(device, reportId, data)
+        if (!ok) {
+            Log.w("HidDeviceManager", "sendReport failed for reportId=$reportId")
+        }
+    }
+
+    private fun hasConnectPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED &&
+                ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+
+    private fun clampToSignedByte(value: Int): Byte {
+        return value.coerceIn(-127, 127).toByte()
+    }
+
+    private fun keycodeForChar(c: Char): Byte? {
+        return when (c.lowercaseChar()) {
+            in 'a'..'z' -> (0x04 + (c.lowercaseChar() - 'a')).toByte()
+            in '1'..'9' -> (0x1E + (c - '1')).toByte()
+            '0' -> 0x27
+            ' ' -> 0x2C
+            '\n' -> 0x28
+            else -> null
+        }
+    }
+
+    companion object {
+        const val REPORT_ID_MOUSE = 1
+        const val REPORT_ID_KEYBOARD = 2
+
+        val HID_REPORT_DESCRIPTOR = byteArrayOf(
+            0x05, 0x01,
+            0x09, 0x02,
+            0xA1.toByte(), 0x01,
+            0x85.toByte(), REPORT_ID_MOUSE.toByte(),
+            0x09, 0x01,
+            0xA1.toByte(), 0x00,
+            0x05, 0x09,
+            0x19, 0x01,
+            0x29, 0x03,
+            0x15, 0x00,
+            0x25, 0x01,
+            0x95.toByte(), 0x03,
+            0x75, 0x01,
+            0x81.toByte(), 0x02,
+            0x95.toByte(), 0x01,
+            0x75, 0x05,
+            0x81.toByte(), 0x01,
+            0x05, 0x01,
+            0x09, 0x30,
+            0x09, 0x31,
+            0x09, 0x38,
+            0x15, 0x81.toByte(),
+            0x25, 0x7F,
+            0x75, 0x08,
+            0x95.toByte(), 0x03,
+            0x81.toByte(), 0x06,
+            0xC0.toByte(),
+            0xC0.toByte(),
+
+            0x05, 0x01,
+            0x09, 0x06,
+            0xA1.toByte(), 0x01,
+            0x85.toByte(), REPORT_ID_KEYBOARD.toByte(),
+            0x05, 0x07,
+            0x19, 0xE0.toByte(),
+            0x29, 0xE7.toByte(),
+            0x15, 0x00,
+            0x25, 0x01,
+            0x75, 0x01,
+            0x95.toByte(), 0x08,
+            0x81.toByte(), 0x02,
+            0x95.toByte(), 0x01,
+            0x75, 0x08,
+            0x81.toByte(), 0x01,
+            0x95.toByte(), 0x06,
+            0x75, 0x08,
+            0x15, 0x00,
+            0x25, 0x65,
+            0x05, 0x07,
+            0x19, 0x00,
+            0x29, 0x65,
+            0x81.toByte(), 0x00,
+            0xC0.toByte()
+        )
+    }
+}

--- a/android-client/app/src/main/java/com/remotebrain/hid/MainActivity.kt
+++ b/android-client/app/src/main/java/com/remotebrain/hid/MainActivity.kt
@@ -1,0 +1,87 @@
+package com.remotebrain.hid
+
+import android.Manifest
+import android.os.Build
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity(), HidDeviceManager.Listener {
+    private lateinit var statusText: TextView
+    private lateinit var connectButton: Button
+    private lateinit var keyboardInput: EditText
+    private lateinit var sendButton: Button
+    private lateinit var touchpad: TouchpadView
+
+    private lateinit var hidManager: HidDeviceManager
+
+    private val permissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) {
+        val granted = it.values.all { value -> value }
+        onStatusChanged(if (granted) "Permissions granted" else "Bluetooth permissions required")
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        statusText = findViewById(R.id.statusText)
+        connectButton = findViewById(R.id.registerButton)
+        keyboardInput = findViewById(R.id.keyboardInput)
+        sendButton = findViewById(R.id.sendButton)
+        touchpad = findViewById(R.id.touchpad)
+
+        hidManager = HidDeviceManager(this, this)
+        hidManager.bindService()
+
+        connectButton.setOnClickListener {
+            ensureBluetoothPermissions()
+            hidManager.registerAndConnect()
+        }
+
+        sendButton.setOnClickListener {
+            val text = keyboardInput.text.toString()
+            hidManager.sendText(text)
+            keyboardInput.setText("")
+        }
+
+        touchpad.listener = object : TouchpadView.Listener {
+            override fun onMove(dx: Int, dy: Int) {
+                hidManager.sendMouseMove(dx, dy)
+            }
+
+            override fun onTap() {
+                hidManager.sendMouseClickLeft()
+            }
+
+            override fun onTwoFingerScroll(deltaY: Int) {
+                hidManager.sendScroll(deltaY)
+            }
+        }
+    }
+
+    private fun ensureBluetoothPermissions() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            permissionLauncher.launch(
+                arrayOf(
+                    Manifest.permission.BLUETOOTH_CONNECT,
+                    Manifest.permission.BLUETOOTH_SCAN
+                )
+            )
+        }
+    }
+
+    override fun onStatusChanged(text: String) {
+        runOnUiThread { statusText.text = text }
+    }
+
+    override fun onDeviceConnected(connected: Boolean) {
+        runOnUiThread {
+            connectButton.text = if (connected) getString(R.string.connected) else getString(R.string.register_connect)
+        }
+    }
+}

--- a/android-client/app/src/main/java/com/remotebrain/hid/TouchpadView.kt
+++ b/android-client/app/src/main/java/com/remotebrain/hid/TouchpadView.kt
@@ -1,0 +1,78 @@
+package com.remotebrain.hid
+
+import android.content.Context
+import android.graphics.Color
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import kotlin.math.abs
+
+class TouchpadView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : View(context, attrs) {
+
+    interface Listener {
+        fun onMove(dx: Int, dy: Int)
+        fun onTap()
+        fun onTwoFingerScroll(deltaY: Int)
+    }
+
+    var listener: Listener? = null
+
+    private var lastX = 0f
+    private var lastY = 0f
+    private var downX = 0f
+    private var downY = 0f
+    private var downAt = 0L
+
+    init {
+        setBackgroundColor(Color.parseColor("#1F1F1F"))
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                downX = event.x
+                downY = event.y
+                lastX = event.x
+                lastY = event.y
+                downAt = event.eventTime
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                if (event.pointerCount >= 2) {
+                    val avgY = (event.getY(0) + event.getY(1)) / 2f
+                    val deltaY = (avgY - lastY).toInt()
+                    if (deltaY != 0) {
+                        listener?.onTwoFingerScroll(deltaY / 2)
+                    }
+                    lastY = avgY
+                } else {
+                    val dx = (event.x - lastX).toInt()
+                    val dy = (event.y - lastY).toInt()
+                    if (dx != 0 || dy != 0) {
+                        listener?.onMove(dx, dy)
+                    }
+                    lastX = event.x
+                    lastY = event.y
+                }
+            }
+
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                if (event.pointerCount >= 2) {
+                    lastY = (event.getY(0) + event.getY(1)) / 2f
+                }
+            }
+
+            MotionEvent.ACTION_UP -> {
+                val dt = event.eventTime - downAt
+                val moved = abs(event.x - downX) + abs(event.y - downY)
+                if (dt < 180 && moved < 25f) {
+                    listener?.onTap()
+                }
+            }
+        }
+        return true
+    }
+}

--- a/android-client/app/src/main/res/layout/activity_main.xml
+++ b/android-client/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/statusLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Status"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/statusText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Not connected"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/statusLabel" />
+
+    <Button
+        android:id="@+id/registerButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="Register / Connect HID"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/statusText" />
+
+    <com.remotebrain.hid.TouchpadView
+        android:id="@+id/touchpad"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        android:contentDescription="Touchpad"
+        app:layout_constraintBottom_toTopOf="@id/keyboardInput"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/registerButton" />
+
+    <EditText
+        android:id="@+id/keyboardInput"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:hint="Type and send as HID keys"
+        app:layout_constraintBottom_toTopOf="@id/sendButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/sendButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Send keyboard input"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-client/app/src/main/res/values/colors.xml
+++ b/android-client/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+</resources>

--- a/android-client/app/src/main/res/values/strings.xml
+++ b/android-client/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="app_name">RemoteBrain HID</string>
+    <string name="connected">Connected</string>
+    <string name="register_connect">Register / Connect HID</string>
+</resources>

--- a/android-client/app/src/main/res/values/themes.xml
+++ b/android-client/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.RemoteBrainHid" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/black</item>
+    </style>
+</resources>

--- a/android-client/build.gradle.kts
+++ b/android-client/build.gradle.kts
@@ -1,0 +1,10 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.4.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+    }
+}

--- a/android-client/gradle.properties
+++ b/android-client/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/android-client/settings.gradle.kts
+++ b/android-client/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "remote-brain-hid"
+include(":app")

--- a/docs/how-to-run-bluetooth-hid.md
+++ b/docs/how-to-run-bluetooth-hid.md
@@ -1,0 +1,39 @@
+# How to run Bluetooth HID Android client (BT-HID MVP)
+
+## 1) Pair Android phone with Windows over Bluetooth
+1. On Windows, open **Settings → Bluetooth & devices** and enable Bluetooth.
+2. Click **Add device → Bluetooth**.
+3. On Android, open Bluetooth settings and make the phone discoverable if needed.
+4. Pair the phone with the Windows machine and confirm pairing codes on both sides.
+5. Keep the device bonded (paired) before launching the HID connect flow.
+
+> The app currently connects to the **first bonded device** on the phone. If multiple hosts are paired, unpair unused devices for predictable behavior.
+
+## 2) Run app from Android Studio
+1. Open Android Studio and choose **Open**.
+2. Select the `android-client/` folder from this repository.
+3. Let Gradle sync finish.
+4. Connect a physical Android device (API 28+ required, Bluetooth hardware required).
+5. Run the `app` configuration.
+6. In app:
+   - Tap **Register / Connect HID**.
+   - Grant Bluetooth permissions when prompted.
+   - Confirm connection status changes to connected.
+
+## 3) Use controls
+- **Touchpad drag**: sends relative mouse movement.
+- **Tap touchpad**: sends left click.
+- **Two-finger drag**: sends mouse wheel scroll.
+- **Keyboard input field**: type text and tap **Send keyboard input**.
+
+## 4) Common permission and pairing issues
+- **No permission dialog appears / connect fails on Android 12+**:
+  - Ensure app has `BLUETOOTH_CONNECT` and `BLUETOOTH_SCAN` in system app permissions.
+  - Revoke and re-grant permissions from app settings if needed.
+- **Status shows HID service not ready**:
+  - Wait a moment after app startup; HID profile proxy binding is asynchronous.
+- **Status shows pair first**:
+  - Pair phone with Windows in system Bluetooth settings before registering/connecting.
+- **No pointer movement on Windows**:
+  - Confirm Windows still shows the phone as connected Bluetooth input device.
+  - Retry by toggling Bluetooth off/on and reconnecting.


### PR DESCRIPTION
### Motivation
- Provide a minimal Android client that can act as a Bluetooth HID combo device (mouse + keyboard) as part of the BT-HID milestone. 
- Deliver an end-to-end MVP that registers the HID profile, sends mouse/keyboard reports, and exposes a simple touch/keyboard UI for real-device testing. 
- Ensure Android 12+ Bluetooth runtime permission handling is included so the app can run on modern devices. 
- Related to: `Milestone BT-HID — Android app acts as Bluetooth mouse/keyboard (HID Device MVP)`.

### Description
- Added a full Android Studio Kotlin project under `android-client/` with Gradle setup files and app module configured to use package `com.remotebrain.hid`.
- Implemented HID logic in `HidDeviceManager.kt` using the `BluetoothHidDevice` API, including a combo HID report descriptor (mouse + keyboard), SDP registration, connecting to a bonded host, and methods to send mouse and keyboard reports (`sendMouseMove`, `sendMouseClickLeft`, `sendScroll`, `sendText`).
- Implemented minimal UI and interaction in `MainActivity.kt` and `TouchpadView.kt` with connection status display, a `Register / Connect HID` button, a touchpad that maps drag/tap/two-finger gestures to mouse move/click/scroll, and a keyboard input field plus send button to emit HID key events.
- Added required Bluetooth permissions (including `BLUETOOTH_CONNECT` and `BLUETOOTH_SCAN`) to `AndroidManifest.xml`, and included a `docs/how-to-run-bluetooth-hid.md` explaining pairing with Windows, running from Android Studio, and common permission issues.

### Testing
- Ran `gradle -v` inside `android-client/` which succeeded and confirmed a usable Gradle environment.
- Attempted `gradle :app:assembleDebug` which failed in this CI environment due to external repository access returning HTTP 403 (network/repo access issue), so build artifacts could not be produced here; the failure is environmental and not an assertion about project source correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b4d9ab9308322b48983b9b2bcd97d)