### PR TITLE
CI: build Android APK and publish downloadable artifact (text-only)

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -1,0 +1,46 @@
+name: Android APK CI
+
+on:
+  pull_request:
+    paths:
+      - 'android-client/**'
+      - '.github/workflows/android-apk.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'android-client/**'
+      - '.github/workflows/android-apk.yml'
+  workflow_dispatch:
+
+jobs:
+  build-apk:
+    name: Build Android APK
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: android-client
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build debug APK
+        run: gradle app:assembleDebug
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-debug-apk
+          path: android-client/app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Android build outputs
+**/*.apk
+**/*.aab
+**/build/
+**/.gradle/

--- a/docs/how-to-run-bluetooth-hid.md
+++ b/docs/how-to-run-bluetooth-hid.md
@@ -37,3 +37,14 @@
 - **No pointer movement on Windows**:
   - Confirm Windows still shows the phone as connected Bluetooth input device.
   - Retry by toggling Bluetooth off/on and reconnecting.
+
+## 5) Download APK from CI
+The repository includes a GitHub Actions workflow at `.github/workflows/android-apk.yml` that builds a debug APK for pull requests, pushes to `main`, and manual runs.
+
+1. Open the repository in GitHub.
+2. Go to **Actions → Android APK CI**.
+3. Open a successful run.
+4. In the **Artifacts** section, download **android-debug-apk**.
+5. Extract the ZIP and install the APK from `app/build/outputs/apk/debug/` on your Android test device.
+
+> Note: CI publishes a debug APK artifact for testing and does not commit APK binaries into the repository.


### PR DESCRIPTION
### Motivation
- Prevent binary files from blocking PRs by ensuring build outputs are not committed and are ignored. 
- Provide a reproducible CI job that builds an Android debug APK and publishes it as a downloadable artifact for testers without committing APK binaries. 
- Update documentation to explain how to download CI-produced APKs so reviewers and testers can access builds safely.

### Description
- Added a GitHub Actions workflow at `.github/workflows/android-apk.yml` that builds the debug APK (`gradle app:assembleDebug`) on pull requests, pushes to `main`, and manual dispatch, and uploads the APK as the `android-debug-apk` artifact. 
- Added a root `.gitignore` containing Android build/output ignores including `**/*.apk`, `**/*.aab`, `**/build/`, and `**/.gradle/`. 
- Updated `docs/how-to-run-bluetooth-hid.md` with a `Download APK from CI` section that explains how to retrieve the debug APK artifact from GitHub Actions. 
- Ensured no APKs or other binary artifacts were added to the change set and removed any binary files from the working changes (none were present when this change was prepared). 

### Testing
- Ran `git status --porcelain=v1` to assert the working tree state and ensure only intended files were changed, which succeeded. 
- Executed a Python-based binary-detection script to inspect staged/changed files and it reported all changed files as text, which succeeded. 
- Verified the staged change list with `git status --short` to confirm the workflow, `.gitignore`, and docs updates were staged before publishing the PR, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6353011c8322abaa4c4518ce6f2e)